### PR TITLE
Maz style updates

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,4 @@
+/* TODO // once linked from head correctly, move all css in to here */
+body {
+    border: 4px solid tomato !important; /* remove me */
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Question bot</title>
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+    <!-- TODO: move styles here => <link rel="stylesheet" href="../assets/style.css"> --> 
     <style>
         .chat-body {
             width: 800px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,45 +4,226 @@
 <head>
     <meta charset="UTF-8">
     <title>Question bot</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@300;400;500;700&family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
     <!-- TODO: move styles here => <link rel="stylesheet" href="../assets/style.css"> --> 
     <style>
+        /* TODO move out to asset/style.css */
+        
+        /* utililty for screen reader only text */
+        .sr-only:not(:focus):not(:active) {
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+            height: 1px;
+            overflow: hidden;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+        }
+
+        :root {
+            --black-full: #000000;
+            --black: #212121;
+            --white: #eeeeee;
+            --gray-brand: #393e46;
+            --gray-2: #3b3b3b;
+            --gray-1: #505050;
+            --gradient-1: linear-gradient(to right, var(--brand-mid), var(--brand-color) 30%);
+
+            --brand-color: #4ecca3;
+            --brand-color-darker: #4abc93;
+
+            --brand-mid: #41a581;
+            --brand-dark: #317a5e;
+
+            --box-shadow-1: 0px 4px 16px -6px rgba(0, 0, 0, 1);
+            --box-shadow-2: 10px 14px 21px -9px rgba(0, 0, 0, 0.95);
+            --box-shadow-3: 0px 4px 16px -6px rgba(0, 0, 0, 0.35);
+
+            
+            --validation-success-color: var(--brand-mid);
+            --validation-error-color: rgb(247, 119, 97); /* change this */
+
+            --inset-border: inset 0 0 0 3px;
+            --inset-border-thin: inset 0 0 0 1px;
+
+            --font-family: font-family: 'Open Sans', sans-serif;
+        }
+        body, html {
+            min-height: 100vh;
+            /* border: 1px solid pink; */
+            padding: 0;
+            margin:0;
+            background-color: var(--black);
+        }
+
+        body {
+            font-family: var(--font-family);
+        }
+
+        .helper-nav {
+            padding: 1rem;
+            background-color: var(--brand-color);
+            background: var(--gradient-1);
+            box-shadow: var(--box-shadow-1);
+
+        }
+        .helper-logo {
+            width: 100px;
+        }
+
+        .helper-header {
+            padding: 1.5rem 1rem 1rem;
+        }
+
+        .helper-content {
+            box-shadow: var(--box-shadow-1);
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
         .chat-body {
-            width: 800px;
+            width: 100%;
+            padding: 5rem 2rem;
             margin: 50px auto;
         }
 
         .card-body {
-            background-color: #333;
+            /* border: 4px solid green; */
+            /* background-color: #333; */
+            /* background-color: red; */
+            background-color: var(--gray-1);
             color: #fff;
             border-radius: 10px;
         }
 
-        .server-message {
-            background-color: #444;
-            padding: 10px;
-            margin: 10px;
+        .helper-heading {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+
+        .helper-input-controls {
+            /* change to flex after media size met */
+        }
+
+        .helper-messaging-form {
+            padding-top: 1rem;
+        }
+
+        .helper-input-controls__input-wrapper {
+            margin-bottom: 1rem;
+        }
+        .helper-input-controls__input-label {
+            display: block;
+            margin-bottom: 0.3rem;
+            font-size: 18px;
+        }
+
+        .helper-input-controls__input-wrapper input {
+            width: 100%;
+            font-size: 16px; /* keep to min 16 to stop zoom in on iOS */ 
+            box-shadow: var(--inset-border-thin) var(--white);
+        }
+        .helper-input-controls__input-wrapper input:focus {
+            outline: none; /* a11y ok as it's replaced below */
+            box-shadow: var(--inset-border) var(--brand-color);
+        }
+
+
+        .helper__submit-btn {
+            font-weight: bold;
+            width: 100%;
+            padding: 0.5rem;
+            border-radius: 3px;
+            background-color: var(--brand-color-darker);
+        }
+        .helper__submit-btn:focus {
+            outline: none; /* a11y ok as it's replaced below */
+            box-shadow: var(--inset-border) var(--white);
+        }
+        .helper__submit-btn:hover {
+            background-color: var(--brand-color);
+        }
+        .helper__submit-btn:active {
+            background-color: var(--brand-mid);
+        }
+
+        @media screen and (min-width: 50rem) {
+            
+            .helper-input-controls {
+                display: flex;
+                align-items: stretch;
+                gap: 0.5rem;
+            }
+            .helper__submit-btn {
+                height: 100%;
+            }
+
+            .helper-input-controls__input-wrapper {
+                flex: 1;
+                margin: 0;
+            }
+            .helper-input-controls__input-wrapper input {
+                margin: 0;
+            }
+
+            .helper-input-controls__actions {
+                min-width: 7rem;   
+            }
+        }
+
+        .client-message,
+        .server-message,
+        .source-message {
+            width: 85%;
+            padding: 1rem 1.2rem;
+            margin-bottom: 1rem;
             border-radius: 10px;
         }
 
+        .client-message {
+            background-color: var(--brand-dark);
+        }
+
+        .server-message,
         .source-message {
+            transform: translateX(1rem);
+        }
+
+        .server-message {
+            position: relative;
             background-color: #444;
-            padding: 10px;
-            margin: 10px;
-            border-radius: 10px;
+            background-color: var(--black);
+        }
+
+        .source-message::after,
+        .server-message::after {
+            content: '';
+            display: block;
+            position: absolute;
+            top: -12px;
+            left: 8px;
+            width: 18px;
+            height: 18px;
+            border-left: 16px solid transparent;
+            border-right: 16px solid transparent;
+            border-bottom: 16px solid var(--black);
+        }
+
+        .source-message::after {
+            border-color: #444;
+        }
+
+        .source-message {
+            position: relative;
+            background-color: #444;
         }
 
         .source-item {
             font-size: small;
             font-style: italic;
-        }
-
-
-        .client-message {
-            background-color: #357434;
-            padding: 10px;
-            margin: 10px;
-            border-radius: 10px;
         }
 
         .form-inline {
@@ -61,11 +242,11 @@
         }
 
         #send {
-            background-color: #4C4CFF;
+            /* background-color: #4C4CFF;
             color: #fff;
             border: none;
             border-radius: 5px;
-            padding: 10px 20px;
+            padding: 10px 20px; */
         }
 
         .form-message {
@@ -182,22 +363,41 @@
     </script>
 </head>
 
-<body class="bg-black">
-    <div class="chat-body card">
-        <div class="card-body p-5">
-            <h4 class="card-title text-center text-xl font-medium"> Document Chat </h4>
-            <p class="card-text text-center text-sm" id="header"> Ask a question about the documents?
-            </p>
+<body>
+    <nav class="helper-nav">
+        <svg class="helper-logo" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3000 926.64"><defs><style>.cls-1{fill:#393e46;}.cls-2{fill:#eee;}</style></defs><g id="SvgjsG2224"><path class="cls-1" d="M486.49,81.08,81.08,312.74V776.06l405.41,231.66L891.78,776.13l.11-.18V312.74Zm0,89.18L774.79,335l-78,44.57L486.49,259.42,276.21,379.59l-78-44.61ZM657.86,446.48V597.74L525.51,522.16V370.89Zm-210.4-75.59V522.13l-132.31,75.6V446.48Zm0,525.37L159.09,731.49V401.84l78,44.57V686.88L447.46,807.1ZM354.1,664.6,486.45,589,618.83,664.6,486.49,740.2Zm459.78,66.89L525.51,896.26V807.1L735.87,686.93V446.41l78-44.57V731.49Z" transform="translate(-81.08 -81.08)"/></g><g id="SvgjsG2225"><path class="cls-2" d="M1151.86,235.14V420.41h2.06a122.91,122.91,0,0,1,104.7-59.23q68.18,0,98.83,34.44t30.65,108.82V726.91h-97.8V524.42q0-43.39-14.12-64.75t-48.56-21.35q-39.25,0-57.51,23.76t-18.25,78.18V726.91h-97.81V235.14Zm475.24,126q50.28,0,89.54,23.42t61.65,67.84q22.38,44.43,22.38,102.28,0,5.5-.69,17.91h-256.9q1.37,42.71,22.38,66.46t64.4,23.77a94,94,0,0,0,49.25-13.43q22.38-13.44,28.58-32.72h86.09q-37.87,119.85-166.68,119.84-48.9-.69-90.57-21.35t-66.46-64.4q-24.79-43.72-24.8-101.59,0-54.4,25.14-99.18t66.81-66.81a189.26,189.26,0,0,1,89.88-22Zm75.08,149.46q-6.89-39.94-25.48-57.86t-53-17.9q-35.82,0-56.48,20.31t-24.1,55.45Zm256.22-275.5V726.91h-97.81V235.14Zm277.57,126q73.7,0,117.78,51.66t44.08,139.81q0,80.6-42.36,132.25t-114,51.65q-70.26,0-106.76-53.72h-1.38V852.27h-97.8V370.82h93v45.46h1.38Q2165,361.19,2236,361.18ZM2129.9,549.9q0,52.35,22,82.65t63.37,30.31q42.71,0,63.71-30.31t21-82.65q0-53.73-22.72-84.37t-63.37-30.65q-40.63,0-62.33,30.3t-21.7,84.72ZM2621,361.18q50.28,0,89.54,23.42t61.64,67.84q22.39,44.43,22.39,102.28,0,5.5-.69,17.91H2537q1.38,42.71,22.38,66.46t64.4,23.77A94,94,0,0,0,2673,649.43q22.38-13.44,28.58-32.72h86.1Q2749.78,736.56,2621,736.55q-48.9-.69-90.57-21.35T2464,650.8q-24.79-43.72-24.8-101.59,0-54.4,25.14-99.18t66.81-66.81a189.33,189.33,0,0,1,89.89-22Zm75.07,149.46q-6.89-39.94-25.48-57.86t-53-17.9q-35.8,0-56.47,20.31T2537,510.64Zm363.67-149.46q12.39,0,21.35,3.44v90.92A165.41,165.41,0,0,0,3046,452.1q-96.42,0-96.42,114.33V726.91h-97.81V370.82h93v66.12h1.37a120.6,120.6,0,0,1,45.81-55.1q31.34-20.65,67.84-20.66Z" transform="translate(-81.08 -81.08)"/></g></svg>
+    </nav>
+    <main class="chat-body card">
+        <div class="helper-content card-body p-5">
+            <header class="helper-header">
+                <h1 class="card-title text-center text-xl font-medium helper-heading">
+                    Document Chat
+                </h1>
+                <p class="card-text text-center" id="header">
+                    Ask a question about the documents?
+                </p>
+            </header>
+            
             <hr class="border-gray-500 mb-5" style="margin-top: 20px;">
             <div id="messages" class="overflow-auto" style="max-height: 500px;">
             </div>
-            <form action="" class="form-inline mt-5" id="chat-form" onsubmit="sendMessage(event)">
-                <input type="text" class="form-control" placeholder="Write your question" id="messageText">
-                <!--value="What is the policy for offsite backups?"-->
-                <button id="send" type="submit" class="btn btn-primary">Ask</button>
+
+            <form action="" class="helper-messaging-form" id="chat-form" onsubmit="sendMessage(event)">
+                <div class="helper-input-controls">
+                    <div class="helper-input-controls__input-wrapper">
+                        <label class="sr-only helper-input-controls__input-label" for="messageText">Your question</label>
+                        <input autofocus type="text" class="form-control" placeholder="Write your question" id="messageText">
+                    </div>
+
+                    <div class="helper-input-controls__actions">
+                        <!--value="What is the policy for offsite backups?"-->
+                        <button id="send" type="submit" class="helper__submit-btn">Ask</button>
+                    </div>
+
+                </div>
             </form>
         </div>
-    </div>
+    </main>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -356,14 +356,14 @@
                     var header = document.getElementById('header');
                     header.innerHTML = "Ask a question";
                     var button = document.getElementById('send');
-                    button.innerHTML = "Send";
+                    button.innerHTML = "Ask";
                     button.disabled = false;
                 } else if (data.type === "error") {
                     console.log(data);
                     var header = document.getElementById('header');
                     header.innerHTML = "Ask a question";
                     var button = document.getElementById('send');
-                    button.innerHTML = "Send";
+                    button.innerHTML = "Ask";
                     button.disabled = false;
                     var p = messages.lastChild.lastChild;
 
@@ -413,7 +413,7 @@
                     Document Chat
                 </h1>
                 <p class="card-text text-center" id="header">
-                    Ask a question about the documents?
+                    Ask a question about the documents
                 </p>
             </header>
             

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,8 @@
     <!-- TODO: move styles here => <link rel="stylesheet" href="../assets/style.css"> --> 
     <style>
         /* TODO move out to asset/style.css */
+
+
         
         /* utililty for screen reader only text */
         .sr-only:not(:focus):not(:active) {
@@ -30,6 +32,7 @@
             --gray-brand: #393e46;
             --gray-2: #3b3b3b;
             --gray-1: #505050;
+            --gray-0: #8d8b8b;
             --gradient-1: linear-gradient(to right, var(--brand-mid), var(--brand-color) 30%);
 
             --brand-color: #4ecca3;
@@ -51,6 +54,15 @@
 
             --font-family: font-family: 'Open Sans', sans-serif;
         }
+
+        html {
+            box-sizing: border-box;
+        }
+
+        *, *::before, *::after {
+            box-sizing: inherit;
+        }
+
         body, html {
             min-height: 100vh;
             /* border: 1px solid pink; */
@@ -61,6 +73,8 @@
 
         body {
             font-family: var(--font-family);
+            display: flex;
+            flex-flow: column nowrap;
         }
 
         .helper-nav {
@@ -78,22 +92,37 @@
             padding: 1.5rem 1rem 1rem;
         }
 
+        .helper-header__logo-icon {
+            width: 50px;
+            margin: 1rem auto;
+            opacity: 0.4;
+
+        }
+        .helper-header__logo-icon svg {
+            fill: var(--white);
+        }
+
         .helper-content {
             box-shadow: var(--box-shadow-1);
+            
+            width: 90%;
             max-width: 800px;
             margin: 0 auto;
+            
         }
 
         .chat-body {
             width: 100%;
-            padding: 5rem 2rem;
-            margin: 50px auto;
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding-top: 2rem;
+            padding-bottom: 9rem;
+
         }
 
         .card-body {
-            /* border: 4px solid green; */
-            /* background-color: #333; */
-            /* background-color: red; */
             background-color: var(--gray-1);
             color: #fff;
             border-radius: 10px;
@@ -105,7 +134,11 @@
         }
 
         .helper-input-controls {
-            /* change to flex after media size met */
+            padding-top: 1rem;
+            margin-top: 1rem;
+            border-top: 1px solid var(--gray-0);
+
+            /* TODO: ? this could suit being fixed at the bottom - maybe even just for mobile */
         }
 
         .helper-messaging-form {
@@ -138,6 +171,7 @@
             padding: 0.5rem;
             border-radius: 3px;
             background-color: var(--brand-color-darker);
+            transition: background-color 0.2s ease-out;
         }
         .helper__submit-btn:focus {
             outline: none; /* a11y ok as it's replaced below */
@@ -148,6 +182,9 @@
         }
         .helper__submit-btn:active {
             background-color: var(--brand-mid);
+        }
+        .helper__submit-btn:disabled {
+            background-color: var(--brand-dark);
         }
 
         @media screen and (min-width: 50rem) {
@@ -194,7 +231,6 @@
 
         .server-message {
             position: relative;
-            background-color: #444;
             background-color: var(--black);
         }
 
@@ -213,7 +249,7 @@
         }
 
         .source-message::after {
-            border-color: #444;
+            border-bottom-color: #444;
         }
 
         .source-message {
@@ -370,6 +406,9 @@
     <main class="chat-body card">
         <div class="helper-content card-body p-5">
             <header class="helper-header">
+                <div class="helper-header__logo-icon">
+                    <svg id="Layer_1" viewBox="0 0 136.57 156.08"><g id="SvgjsG2224"><path d="M80,2,11.72,41v78L80,158l68.26-39,0,0V41Zm0,15,48.56,27.75-13.13,7.5L80,32,44.58,52.24,31.44,44.73Zm28.86,46.53V89L86.57,76.25V50.77ZM73.43,50.77V76.25L51.14,89V63.51Zm0,88.49L24.86,111.51V56L38,63.5V104l35.44,20.25Zm-15.73-39L80,87.51l22.3,12.73L80,113Zm77.44,11.27L86.57,139.26v-15L122,104V63.5L135.14,56v55.52Z" transform="translate(-11.72 -1.96)"/></g></svg>
+                </div>
                 <h1 class="card-title text-center text-xl font-medium helper-heading">
                     Document Chat
                 </h1>
@@ -378,8 +417,7 @@
                 </p>
             </header>
             
-            <hr class="border-gray-500 mb-5" style="margin-top: 20px;">
-            <div id="messages" class="overflow-auto" style="max-height: 500px;">
+            <div id="messages" class="helper-messages">
             </div>
 
             <form action="" class="helper-messaging-form" id="chat-form" onsubmit="sendMessage(event)">


### PR DESCRIPTION
## Summary of changes
- responsive changes for better viewing on small screens
- add branding with colours and logo
- add new dark mode colour scheme (see new vars in CSS for values)
- allow full page to scroll for now and question to be asked at the bottom. Assume user will need to read the latest reply and scroll anyway. Simplifies scrolling on small screens and avoids double scroll bars. (Can look at other solutions in future if you'd prefer to keep that input always visible)
- make button text consistent - always says 'ask'
- indent chatbot responses to differentiate further between user input and bot responses
- auto focus the input on page load
- focus and hover states etc for all interactive element

TODO

### Sources
- could put those sources in an accordion to stop the unintentional hover on them as things load. User could click to open if interested to see them.
- could mark the sources up as a list and space items out a bit for easier hover
- could offer a touch accessible version of the sources hover data
