### PR TITLE
add meta tag for responsive viewport

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Question bot</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
adds missing responsive meta data to the HTML head to set the width of the site to the width of the device.
This should fix the issues with unexpected zooming and scrolling 
